### PR TITLE
Add settings option to example menus

### DIFF
--- a/example/res/menu/example_list.xml
+++ b/example/res/menu/example_list.xml
@@ -4,6 +4,7 @@
     <item android:id="@+id/about" android:title="@string/about" android:showAsAction="never" android:orderInCategory="1"></item>
     <item android:id="@+id/licenses" android:title="@string/licenses" android:showAsAction="never" android:orderInCategory="2"></item>
     <item android:id="@+id/contact" android:title="@string/contact" android:orderInCategory="3" android:showAsAction="never"></item>
+    <item android:id="@+id/settings" android:title="@string/settings" android:orderInCategory="4" android:icon="@android:drawable/ic_menu_preferences" android:showAsAction="never"></item>
     
 
 </menu>

--- a/example/res/menu/main.xml
+++ b/example/res/menu/main.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
     <item android:id="@+id/github" android:icon="@drawable/ic_action_github" android:showAsAction="always" android:title="@string/github_label" android:titleCondensed="@string/github" android:visible="true"></item>
+    <item android:id="@+id/settings" android:icon="@android:drawable/ic_menu_preferences" android:showAsAction="never" android:title="@string/settings" />
     
 
 </menu>

--- a/example/res/values/strings.xml
+++ b/example/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="about">About</string>
     <string name="licenses">Licenses</string>
     <string name="contact">Contact</string>
+    <string name="settings">Settings</string>
     <string name="about_msg">&lt;b>SlidingMenu&lt;/b> is an Open Source Android library 
         that allows developers to easily create applications with sliding menus like those 
         made popular in the Google+, YouTube, and Facebook applications. 

--- a/example/src/com/jeremyfeinstein/slidingmenu/example/BaseActivity.java
+++ b/example/src/com/jeremyfeinstein/slidingmenu/example/BaseActivity.java
@@ -10,6 +10,7 @@ import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.ListFragment;
 import android.support.v4.view.ViewPager;
+import android.widget.Toast;
 
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuItem;
@@ -59,12 +60,15 @@ public class BaseActivity extends SlidingFragmentActivity {
 		case android.R.id.home:
 			toggle();
 			return true;
-		case R.id.github:
-			Util.goToGitHub(this);
-			return true;
-		}
-		return super.onOptionsItemSelected(item);
-	}
+                case R.id.github:
+                        Util.goToGitHub(this);
+                        return true;
+                case R.id.settings:
+                        Toast.makeText(this, R.string.settings, Toast.LENGTH_SHORT).show();
+                        return true;
+                }
+                return super.onOptionsItemSelected(item);
+        }
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {

--- a/example/src/com/jeremyfeinstein/slidingmenu/example/ExampleListActivity.java
+++ b/example/src/com/jeremyfeinstein/slidingmenu/example/ExampleListActivity.java
@@ -89,20 +89,23 @@ public class ExampleListActivity extends SherlockPreferenceActivity {
 			.setMessage(Html.fromHtml(getString(R.string.apache_license)))
 			.show();
 			break;
-		case R.id.contact:
-			final Intent email = new Intent(android.content.Intent.ACTION_SENDTO);
-			String uriText = "mailto:jfeinstein10@gmail.com" +
-					"?subject=" + URLEncoder.encode("SlidingMenu Demos Feedback"); 
-			email.setData(Uri.parse(uriText));
-			try {
-				startActivity(email);
-			} catch (Exception e) {
-				Toast.makeText(this, R.string.no_email, Toast.LENGTH_SHORT).show();
-			}
-			break;
-		}
-		return super.onOptionsItemSelected(item);
-	}
+                case R.id.contact:
+                        final Intent email = new Intent(android.content.Intent.ACTION_SENDTO);
+                        String uriText = "mailto:jfeinstein10@gmail.com" +
+                                        "?subject=" + URLEncoder.encode("SlidingMenu Demos Feedback");
+                        email.setData(Uri.parse(uriText));
+                        try {
+                                startActivity(email);
+                        } catch (Exception e) {
+                                Toast.makeText(this, R.string.no_email, Toast.LENGTH_SHORT).show();
+                        }
+                        break;
+                case R.id.settings:
+                        Toast.makeText(this, R.string.settings, Toast.LENGTH_SHORT).show();
+                        return true;
+                }
+                return super.onOptionsItemSelected(item);
+        }
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {


### PR DESCRIPTION
## Summary
- add a `settings` string
- add Settings option to the demo menus
- handle new Settings action in BaseActivity and ExampleListActivity

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd3785774832894457d8e94257013